### PR TITLE
判断条件

### DIFF
--- a/permissions/EasyPermissionMicrophone.m
+++ b/permissions/EasyPermissionMicrophone.m
@@ -7,7 +7,7 @@
 
 + (BOOL)authorized
 {
-    return [self authorizationStatus] == AVAudioSessionRecordPermissionGranted;
+    return [self authorizationStatus] == 2;
 }
 
 


### PR DESCRIPTION
xcode13上麦克风权限始终判断为未授权的问题